### PR TITLE
Fix wrong sha-1 for bytes with negative sign.

### DIFF
--- a/sha1.painless
+++ b/sha1.painless
@@ -3,7 +3,10 @@ byte[] digest(byte[] x) {
   int i;
 
   for(i = 0; i < x.length; i++) {
-    blks[i >> 2] |= x[i] << (24 - (i % 4) * 8);
+    int shiftLeftBits = 24 - (i % 4) * 8;
+    int mask = (255 << shiftLeftBits);
+    int value = x[i] << shiftLeftBits;
+    blks[i >> 2] |= value & mask;
   }
 
   blks[i >> 2] |= 0x80 << (24 - (i % 4) * 8);


### PR DESCRIPTION
The sha-1 function doesn't work properly with bytes which happen to be negative.
So the digest is not correct.
i.e. digest(new byte[]{1,-69})